### PR TITLE
Allow configuring multiple hidden layers in AFSS network for GLAD

### DIFF
--- a/ad_examples/glad/afss.py
+++ b/ad_examples/glad/afss.py
@@ -661,7 +661,7 @@ class GladOpts(object):
         self.loda_maxk = args.loda_maxk
         self.loda_debug = args.loda_debug
         self.afss_tau = args.afss_tau
-        self.afss_nodes = [int(n) for n in args.afss_nodes.split(",")]
+        self.afss_nodes = [int(n) if n.isnumeric() else 0 for n in args.afss_nodes.split(",")]
         self.afss_max_labeled_reps = args.afss_max_labeled_reps
         self.afss_c_tau = args.afss_c_tau
         self.afss_l2_lambda = args.afss_l2_lambda

--- a/ad_examples/glad/afss.py
+++ b/ad_examples/glad/afss.py
@@ -613,8 +613,8 @@ def get_glad_option_list():
                              "This is relevant only if the dataset is 2D.")
     parser.add_argument("--afss_tau", type=float, default=0.03, required=False,
                         help="Tau (a guess for the fraction of anomalies, just needs to be small)")
-    parser.add_argument("--afss_nodes", type=int, default=0, required=False,
-                        help="Number of nodes in first layer of AFSS")
+    parser.add_argument("--afss_nodes", type=str, default='', required=False,
+                        help="Number of nodes in each layer of AFSS, comma-separated")
     parser.add_argument("--afss_max_labeled_reps", type=int, default=5, required=False,
                         help="Number of times the labeled instances may be repeated when performing SGD for AFSS")
     parser.add_argument("--max_afss_epochs", type=int, default=1, required=False,
@@ -661,7 +661,7 @@ class GladOpts(object):
         self.loda_maxk = args.loda_maxk
         self.loda_debug = args.loda_debug
         self.afss_tau = args.afss_tau
-        self.afss_nodes = args.afss_nodes
+        self.afss_nodes = [int(n) for n in args.afss_nodes.split(",")]
         self.afss_max_labeled_reps = args.afss_max_labeled_reps
         self.afss_c_tau = args.afss_c_tau
         self.afss_l2_lambda = args.afss_l2_lambda
@@ -688,7 +688,7 @@ class GladOpts(object):
             ensemble_str = "-%s" % self.ensemble_type
         bias_str = ("-bias%0.2f" % self.afss_bias_prob).replace('.', '_')
         c_tau_str = ("-c%0.2f" % self.afss_c_tau).replace('.', '_')
-        nodes_str = "-nodes%d" % self.afss_nodes
+        nodes_str = "-nodes%s" % self.afss_nodes
         reps_sig = "-amr%d" % self.afss_max_labeled_reps
         prior_sig = "-no_prior" if self.afss_lambda_prior == 0 else ""
         prime_sig = "-no_prime" if self.afss_no_prime else ""

--- a/ad_examples/glad/glad_batch.py
+++ b/ad_examples/glad/glad_batch.py
@@ -5,7 +5,7 @@ from .glad_test_support import *
 An implementation of:
     GLAD: *GL*ocalized *A*nomaly *D*etection via Active Feature Space Suppression
 
-python -m ad_examples.glad.glad_batch --log_file=temp/glad/glad_batch.log --debug --dataset=toy2 --n_epochs=200 --afss_bias_prob=0.50 --train_batch_size=25 --budget=60 --afss_nodes=0 --afss_max_labeled_reps=5 --loda_debug --plot
+python -m ad_examples.glad.glad_batch --log_file=temp/glad/glad_batch.log --debug --dataset=toy2 --n_epochs=200 --afss_bias_prob=0.50 --train_batch_size=25 --budget=60 --afss_nodes=25,50 --afss_max_labeled_reps=5 --loda_debug --plot
 """
 
 
@@ -98,7 +98,7 @@ def glad_active_learn(opts):
 
     opts.plot = opts.plot and opts.reruns == 1  # just in case...
 
-    logger.debug("feedback budget: %d, batch_size: %d, afss_nodes: %d" %
+    logger.debug("feedback budget: %d, batch_size: %d, afss_nodes: %s" %
                  (opts.budget, opts.train_batch_size, opts.afss_nodes))
 
     if opts.ensemble_type not in supported_ensemble_types:

--- a/ad_examples/glad/glad_batch.py
+++ b/ad_examples/glad/glad_batch.py
@@ -5,7 +5,7 @@ from .glad_test_support import *
 An implementation of:
     GLAD: *GL*ocalized *A*nomaly *D*etection via Active Feature Space Suppression
 
-python -m ad_examples.glad.glad_batch --log_file=temp/glad/glad_batch.log --debug --dataset=toy2 --n_epochs=200 --afss_bias_prob=0.50 --train_batch_size=25 --budget=60 --afss_nodes=25,50 --afss_max_labeled_reps=5 --loda_debug --plot
+python -m ad_examples.glad.glad_batch --log_file=temp/glad/glad_batch.log --debug --dataset=toy2 --n_epochs=200 --afss_bias_prob=0.50 --train_batch_size=25 --budget=60 --afss_nodes=0 --afss_max_labeled_reps=5 --loda_debug --plot
 """
 
 

--- a/ad_examples/glad/glad_support.py
+++ b/ad_examples/glad/glad_support.py
@@ -108,7 +108,7 @@ class AnomalyEnsembleLoda(AnomalyEnsemble):
 def get_afss_model(opts, n_output=1):
 
     layer_sizes = opts.afss_nodes
-    if len(layer_sizes) == 0 or layer_sizes[0] == 0:
+    if len(layer_sizes) == 0 or any(n < 1 for n in layer_sizes):
         layer_sizes = [max(50, n_output * 3)]
         logger.debug("Setting layer_sizes to [%d]" % layer_sizes[0])
 

--- a/ad_examples/glad/glad_support.py
+++ b/ad_examples/glad/glad_support.py
@@ -107,23 +107,15 @@ class AnomalyEnsembleLoda(AnomalyEnsemble):
 
 def get_afss_model(opts, n_output=1):
 
-    # n_hidden is merely the penultimate [bottle-neck] layer.
-    # In case the network is required to be 'deep', might
-    # need other ways to externalize their configuration.
-    n_hidden = opts.afss_nodes
-    if n_hidden < 1:
-        n_hidden = max(50, n_output * 3)
-        logger.debug("Setting n_hidden nodes to %d" % n_hidden)
+    layer_sizes = opts.afss_nodes
+    if len(layer_sizes) == 0 or layer_sizes[0] == 0:
+        layer_sizes = [max(50, n_output * 3)]
+        logger.debug("Setting layer_sizes to [%d]" % layer_sizes[0])
 
     logger.debug("l2_lambda: %f" % opts.afss_l2_lambda)
     logger.debug("max_afss_epochs: %d" % opts.max_afss_epochs)
 
-    if True:
-        # one-layer neural network when the number of input features is reasonable
-        n_neurons = [n_hidden, n_output]
-    else:
-        # deep network - might prefer a deep network if the number of input features is very large
-        n_neurons = [200, 100, 50, 50, n_hidden, n_output]
+    n_neurons = layer_sizes + [n_output]
 
     names = ["hidden%d" % (i+1) for i in range(len(n_neurons)-1)]
     names.append("output")

--- a/glad.sh
+++ b/glad.sh
@@ -40,8 +40,8 @@ fi
 #      Recommended: AFSS_LAMBDA_PRIOR=1.0
 #   2. AFSS_MAX_LABELED_REPS is the number of times the labeled instances
 #      will be over-sampled during training. Value > 1 helps overcome class-imbalance.
-#   3. If AFSS_NODES=0, GLAD will use max(50, <num_ensemble_members> * 3) nodes 
-#      in the hidden layer. Else, the number of nodes specified will be used.
+#   3. If AFSS_NODES=0, GLAD will use a single layer of
+       max(50, <num_ensemble_members> * 3) nodes.
 # ------------------------------
 AFSS_C_TAU=1.0
 AFSS_LAMBDA_PRIOR=1.0


### PR DESCRIPTION
Updated the argsparse afss_nodes parameter to take a comma-separated string of numbers, which will be split into a list. For example, "--afss_nodes=25,50" 

I did a quick ctrl-F search for "afss_nodes" through the whole repository to check everything was backwards-compatible, and make quick updates to the documentation.

Not specifying --afss_nodes or setting "--afss_nodes=0" will have the same behavior as before.

Changes are compatible with python 2, and I tested glad_batch.py with the suggested command using Python 3.6.